### PR TITLE
desktop.vala: Do not hide the indicator

### DIFF
--- a/src/desktop.vala
+++ b/src/desktop.vala
@@ -64,9 +64,12 @@ class Desktop: Profile
     build_menu ();
 
     // know when to show the indicator & when to hide it
-    settings.changed["visible"].connect (()=> update_visibility());
-    bluetooth.notify["supported"].connect (() => update_visibility());
-    update_visibility ();
+    if (Environment.get_variable("MIR_SOCKET") != null)
+    {
+        settings.changed["visible"].connect (()=> update_visibility());
+        bluetooth.notify["supported"].connect (() => update_visibility());
+        update_visibility ();
+    }
 
     // when devices change, rebuild our device section
     bluetooth.devices_changed.connect (()=> {

--- a/src/killswitch.vala
+++ b/src/killswitch.vala
@@ -129,7 +129,7 @@ public class RfKillSwitch: KillSwitch, Object
     var event = Linux.RfKillEvent();
     var n = sizeof (Linux.RfKillEvent);
     var bytesread = Posix.read (fd, &event, n);
-   
+
     if (bytesread == n)
       {
         process_event (event);


### PR DESCRIPTION
We need to keep the indicator visible at all times because it is connected to a serious amount of signals that control its visibility, many of which can catch the panel indicator applet in an awkward moment (suspending, hibernating etc.).

This change does not affect Lomiri, only other desktops. 

fixes #15