### PR TITLE
src/*.vala: make the switch item & action QMenuModel compatible

### DIFF
--- a/src/desktop.vala
+++ b/src/desktop.vala
@@ -106,7 +106,7 @@ class Desktop: Profile
     var id = device.id;
     var action_name = @"desktop-device-$(id)-connected";
 
-    var item = new MenuItem (_("Connection"), @"indicator.$action_name");
+    var item = new MenuItem (_("Connection"), @"indicator.$(action_name)(true)");
     item.set_attribute ("x-ayatana-type",
                         "s", "org.ayatana.indicator.switch");
 
@@ -118,8 +118,11 @@ class Desktop: Profile
                                            VariantType.BOOLEAN,
                                            new Variant.boolean (device.is_connected));
 
-        a.activate.connect ((action, state)
-          => bluetooth.set_device_connected (id, state.get_boolean()));
+        a.activate.connect ((action, param)
+          => a.change_state (param));
+
+        a.change_state.connect ((action, requestedValue)
+          => bluetooth.set_device_connected (id, requestedValue.get_boolean()));
 
         connect_actions.insert (device.id, a);
         action_group.add_action (a);
@@ -223,7 +226,7 @@ class Desktop: Profile
     // quick toggles section
     section = new Menu ();
     section.append_item (create_enabled_menuitem ());
-    item = new MenuItem (_("Visible"), "indicator.desktop-discoverable");
+    item = new MenuItem (_("Visible"), "indicator.desktop-discoverable(true)");
     item.set_attribute ("x-ayatana-type", "s",
                         "org.ayatana.indicator.switch");
     section.append_item (item);
@@ -271,8 +274,11 @@ class Desktop: Profile
                                             VariantType.BOOLEAN,
                                             new Variant.boolean (bluetooth.discoverable));
 
-    action.activate.connect ((action, state)
-        => bluetooth.try_set_discoverable (state.get_boolean()));
+    action.activate.connect ((action, param)
+        => action.change_state (param));
+
+    action.change_state.connect ((action, requestedValue)
+        => bluetooth.try_set_discoverable (requestedValue.get_boolean()));
 
     bluetooth.notify["discoverable"].connect (()
         => action.set_state (new Variant.boolean (bluetooth.discoverable)));

--- a/src/profile.vala
+++ b/src/profile.vala
@@ -86,7 +86,7 @@ class Profile: Object
 
   protected MenuItem create_enabled_menuitem ()
   {
-    var item = new MenuItem (_("Bluetooth"), "indicator.bluetooth-enabled");
+    var item = new MenuItem (_("Bluetooth"), "indicator.bluetooth-enabled(true)");
 
     item.set_attribute ("x-ayatana-type", "s",
                         "org.ayatana.indicator.switch");
@@ -126,8 +126,11 @@ class Profile: Object
                                             VariantType.BOOLEAN,
                                             new Variant.boolean (bluetooth.enabled));
 
-    action.activate.connect ((action, state)
-        => bluetooth.try_set_enabled (state.get_boolean()));
+    action.activate.connect ((action, param)
+        => action.change_state (param));
+
+    action.change_state.connect ((action, requestedValue)
+        => bluetooth.try_set_enabled (requestedValue.get_boolean()));
 
     bluetooth.notify["enabled"].connect (()
         => action.set_state (new Variant.boolean (bluetooth.enabled)));


### PR DESCRIPTION
QMenuModel, inheritting code from GTK, will consider the menu item not
"activatable" if the item's "target" [1] doesn't match the corresponding
action's parameter. Since we take a boolean as action's parameter (and
we can't change action's parameter easily since it's semi-public), we
instead have to pass "target".

Taking a page from the slider menu items, pass "true" as the target
will make QMenuModel considers the item activatable and reflect the
right state.

And while we're at it, restore the ability to use g_action_change_state
to change the state. This allows the clients that still support
Canonical's indicator (e.g. Lomiri) to not have to distinguish between
that and Ayatana's. This, again, is taken from how the slider menu items
work.

[1] i.e. the parameter to pass when activating the action. See
https://wiki.gnome.org/Projects/GLib/GApplication/DBusAPI#Attributes

Related: https://github.com/AyatanaIndicators/qmenumodel/issues/21

--------------------------------------------

I believe this has 3 benefits:

- It doesn't break ayatana-ido, since it doesn't read the "target" value anyway.
- It unbreaks QMenuModel, since now it considers this action activatable.
- I still have to update Lomiri, but with `g_action_change_state()` I shouldn't have to hardcode org.ayatana.indicator.switch in it anymore.

In the hindsight, the same benefit of the original change (preventing race conditions between multiple clients) could be achieve by just moving ayatana-ido to use `g_action_change_state()` without modifying the action's parameter. However, since the ship has sailed, I guess this works best.